### PR TITLE
Fix fallback ticket creation and support ticket flowFeature/backend lambda setup

### DIFF
--- a/backend/lambda/handler.py
+++ b/backend/lambda/handler.py
@@ -116,7 +116,23 @@ def lambda_handler(event, context):
         # 3) Call OpenAI
         answer = ask_openai(user_query, context_text)
 
-        if (not answer) or (not answer.strip()) or (answer.strip().lower() in ["i don't know", "i do not know", "i'm not sure", "i don't know based on the provided documents."]):
+        answer_text = (answer or "").strip()
+        answer_lower = answer_text.lower().replace("’", "'")
+
+        unknown_phrases = [
+            "i don't know",
+            "i do not know",
+            "i'm not sure",
+            "i am not sure",
+            "i don't know based on the provided documents",
+            "i do not know based on the provided documents",
+            "couldn't find a relevant answer",
+            "couldn't produce a confident answer",
+            "not enough information",
+            "cannot answer based on the provided",
+        ]
+
+        if (not answer_text) or any(phrase in answer_lower for phrase in unknown_phrases):
             ticket = _create_ticket(user_query)
             fallback = (
                 "I'm sorry — I couldn't produce a confident answer. "

--- a/backend/lambda/handler.py
+++ b/backend/lambda/handler.py
@@ -108,7 +108,8 @@ def lambda_handler(event, context):
             ticket = _create_ticket(user_query)
             fallback = (
                 "I'm sorry — I couldn't find a relevant answer in the knowledge base. "
-                "I've created a support ticket so our admissions team can follow up."
+                "I've created a support ticket so our admissions team can follow up. \n\n"
+                "Ticket ID: " + ticket["id"]
             )
             return _response(200, {"response": fallback, "ticket": ticket})
 
@@ -118,7 +119,8 @@ def lambda_handler(event, context):
         if (not answer) or (not answer.strip()) or (answer.strip().lower() in ["i don't know", "i do not know", "i'm not sure", "i don't know based on the provided documents."]):
             ticket = _create_ticket(user_query)
             fallback = (
-                "I couldn't produce a confident answer. I've created a support ticket so our admissions team can follow up.\n"
+                "I'm sorry — I couldn't produce a confident answer. "
+                "I've created a support ticket so our admissions team can follow up. \n\n"
                 "Ticket ID: " + ticket["id"]
             )
             return _response(200, {"response": fallback, "ticket": ticket})

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -53,11 +53,11 @@ function App() {
 
     setIsSending(true);
     try {
-      const response = await sendQuery(trimmed);
+      const { response, ticket } = await sendQuery(trimmed);
       // Give bot message a timestamp too
       setMessages((prev) => [
         ...prev,
-        { role: "bot", text: response, timestamp: new Date().toISOString() },
+        { role: "bot", text: response, ticket: ticket ?? null, timestamp: new Date().toISOString() },
       ]);
       setInput("");
     } catch (e) {
@@ -250,6 +250,17 @@ function App() {
                             {isUser ? "You" : "Helpdesk"}
                           </div>
                           <div className="whitespace-pre-wrap">{msg.text}</div>
+                          {!isUser && msg.ticket?.id && (
+                            <a
+                              href={`/ticket.html?id=${msg.ticket.id}`}
+                              className="mt-2 inline-flex items-center gap-1 text-xs font-semibold text-upou-maroon hover:underline"
+                            >
+                              View your support ticket
+                              <svg aria-hidden="true" viewBox="0 0 24 24" className="h-3 w-3" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+                                <path d="M5 12h12"/><path d="m13 6 6 6-6 6"/>
+                              </svg>
+                            </a>
+                          )}
                         </div>
                       </div>
                     );

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -12,5 +12,5 @@ export async function sendQuery(query) {
   }
 
   const data = await res.json();
-  return data.response;
+  return { response: data.response, ticket: data.ticket ?? null };
 }


### PR DESCRIPTION
Updated the Lambda fallback logic so uncertain AI responses that contain phrases like "I don't know based on the provided documents" now trigger support ticket creation properly.

Tested:
- fallback response creates a DynamoDB ticket
- backend returns the ticket object
- ticket lookup endpoint works
- frontend can open the support ticket tracker